### PR TITLE
ブラウザ終了後もsessionを保持し、ログイン状態を保つ

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,3 @@
+# Be sure to restart your server when you modify this file.
+
+Rails.application.config.session_store :cookie_store, key: '_cofri_session', expire_after: 2.weeks


### PR DESCRIPTION
session_storeに`expire_after: 2.weeks`を設定

ref: [ActionDispatch::Session::CookieStore](https://api.rubyonrails.org/v6.0.0/classes/ActionDispatch/Session/CookieStore.html)